### PR TITLE
arrangeContentSize is referenced also in Release mode

### DIFF
--- a/MasterGrab/CustomControlBase.cs
+++ b/MasterGrab/CustomControlBase.cs
@@ -259,12 +259,12 @@ namespace MasterGrab {
 
     #if DEBUG
     Size arrangeConstraintSize;
-    Size arrangeContentSize;
     Size arrangeRequestedSize;
     #endif
+    Size arrangeContentSize;
 
 
-    private Size doArrangeOverride(Size arrangeBounds) {
+        private Size doArrangeOverride(Size arrangeBounds) {
       /*
       ArrangeOverride() gets called by FrameworkElement.ArrangeCore() which gets called by UIElement.Arrange() 
 
@@ -303,7 +303,6 @@ namespace MasterGrab {
 #if DEBUG
       arrangeConstraintSize = arrangeBounds;
       #else
-      Size arrangeContentSize;
       Size arrangeRequestedSize;
       #endif
 


### PR DESCRIPTION
Moved the `arrangeContentSize` field outside the conditional compilation making it available in both Debug and Release mode.

Fixes #4 